### PR TITLE
Wiener Schnitzel spelling fix

### DIFF
--- a/src/exercises/04_less.rb
+++ b/src/exercises/04_less.rb
@@ -7,7 +7,7 @@
 
     Zum Glück haben Sie die Speisekarte in der Datei `speisekarte.txt` im `#{PROJEKT_PATH}`-Ordner gespeichert.
 
-    Schaue Sie in der Datei nach dem _Preis für ein Wiener-Schnitzel_.
+    Schaue Sie in der Datei nach dem _Preis für ein Wiener Schnitzel_.
   },
   'Welchen Preis hat das Wiener Schnitzel?',
   'less speisekarte.txt',


### PR DESCRIPTION
Same spelling for the same word!

Even not asked here, I used grep Wiener-Schnitzel and because of that different spelling in the file nothing was found...