### PR TITLE
Added cal exercise. 

### DIFF
--- a/schnitzel
+++ b/schnitzel
@@ -717,6 +717,22 @@ CHAOS_FILE_COUNT = 66893
     -> () { p = fork { exec "sleep 100000" }; Process.detach(p) }
 )
 
+# cal
+@exercises << Exercise.new(
+    'Sag niemals nie.',
+    'Machen Sie sich mit der Funktionsweise "cal" vertraut.',
+    %Q{
+      An der Strandbar lernen Sie einen Ureinwohner der karibischen Insel kennen, der Ihnen eine Location für Ihr neues Schnitzelresturant vermieten könnte. Dieser behauptet, dass das Haus von seinen Vorfahren im kürzesten Monat des Jahres 1752 erbaut worden sei.
+      Als der Ureinwohner den Monat nennt, brechen Sie in Lachen aus: "Das war noch nie der kürzeste Monat eines Jahres!"
+      Zum Beweis lassen Sie sich mithilfe des Befehles `cal` den Überblick des Jahres 1752 anzeigen.
+
+     Finden Sie mithilfe der _Jahresübersicht des Befehls `cal`_ heraus, welcher Monat in dem Jahr 1752 der kürzeste Monat war und zählen Sie, wiviele einzelne Tage dieser laut `cal` hatte.
+    },
+    'Wie viele einzelne Tage hatte der kürzeste Monat des Jahres 1752 laut cal?',
+    'cal 1752',
+    -> () { input == '19' }
+)
+
 
 start = next_exercise_from_log
 

--- a/src/exercises/24_cal.rb
+++ b/src/exercises/24_cal.rb
@@ -1,0 +1,15 @@
+# cal
+@exercises << Exercise.new(
+    'Sag niemals nie.',
+    'Machen Sie sich mit der Funktionsweise "cal" vertraut.',
+    %Q{
+      An der Strandbar lernen Sie einen Ureinwohner der karibischen Insel kennen, der Ihnen eine Location für Ihr neues Schnitzelresturant vermieten könnte. Dieser behauptet, dass das Haus von seinen Vorfahren im kürzesten Monat des Jahres 1752 erbaut worden sei.
+      Als der Ureinwohner den Monat nennt, brechen Sie in Lachen aus: "Das war noch nie der kürzeste Monat eines Jahres!"
+      Zum Beweis lassen Sie sich mithilfe des Befehles `cal` den Überblick des Jahres 1752 anzeigen.
+
+     Finden Sie mithilfe der _Jahresübersicht des Befehls `cal`_ heraus, welcher Monat in dem Jahr 1752 der kürzeste Monat war und zählen Sie, wiviele einzelne Tage dieser laut `cal` hatte.
+    },
+    'Wie viele einzelne Tage hatte der kürzeste Monat des Jahres 1752 laut cal?',
+    'cal 1752',
+    -> () { input == '19' }
+)

--- a/src/schnitzel.rb
+++ b/src/schnitzel.rb
@@ -102,6 +102,7 @@ require_relative 'exercises/20_grep_sed.rb'
 require_relative 'exercises/21_ln_s.rb'
 require_relative 'exercises/22_ln.rb'
 require_relative 'exercises/23_ps_kill.rb'
+require_relative 'exercises/24_cal.rb'
 
 start = next_exercise_from_log
 


### PR DESCRIPTION
Added cal exercise. 
It is using the jump between Julian and Gregorian Calendar in 1752 that makes September 1752 per definition the shortest in cal, see https://de.wikipedia.org/wiki/Cal_(Unix)

Using this makes sure that the user does not cheat with a web calendar.
Every other exercise like "What day was xy" would be solvable by every other calendar.

Added in this pull request:
 * Exercise 24 (cal command)
 * included new exercise in schnitzel.rb
 * Updated schnitzel file