### PR TITLE
Added bc exercise

### DIFF
--- a/schnitzel
+++ b/schnitzel
@@ -825,6 +825,7 @@ CHAOS_TXT_FILE_COUNT = 32771
     end
 )
 
+# bc
 @exercises << Exercise.new(
     'Kein unkalkuliertes Business!',
     'Machen Sie sich mit der Funktionsweise von "bc" vertraut.',
@@ -836,8 +837,8 @@ CHAOS_TXT_FILE_COUNT = 32771
 
       Benutzen Sie das Kommando `bc`, um herauszufinden, wieviel 3108 hoch 2000 beträgt.
     },
-    'Geben Sie die letzte Zeile des Ergebnisses an',
-    "",
+    'Geben Sie hier die letzte Zeile des Ergebnisses an:',
+    'echo "(3108^2000)" | bc',
     -> () { read_console == '9443143978953998187590546511579035962672599269376' }
 )
 

--- a/schnitzel
+++ b/schnitzel
@@ -836,9 +836,11 @@ CHAOS_TXT_FILE_COUNT = 32771
       Da Sie dem Finanzamtmitarbeiter nicht trauen, beschließen Sie, diese Zahlen mit Ihrem Rechner auf Plausibilität zu prüfen.
 
       Benutzen Sie das Kommando `bc`, um herauszufinden, wieviel 3108 hoch 2000 beträgt.
+
+      Tipp: Das Ergebnis wird von bc in mehrere Zeilen unterteilt. Diese sind mit einem "\\" getrennt.
     },
     'Geben Sie hier die letzte Zeile des Ergebnisses an:',
-    'echo "(3108^2000)" | bc',
+    'echo "3108^2000" | bc',
     -> () { read_console == '9443143978953998187590546511579035962672599269376' }
 )
 

--- a/schnitzel
+++ b/schnitzel
@@ -641,6 +641,8 @@ CHAOS_FILE_COUNT = 66893
 )
 
 # find / wc
+CHAOS_TXT_FILE_COUNT = 32771
+
 @exercises << Exercise.new(
     'Find what you search for',
     'Machen Sie sich mit der Funktionsweise von find, wc und Pipes zur Ausgabeumleitung (|) vertraut.',
@@ -651,7 +653,7 @@ CHAOS_FILE_COUNT = 66893
     },
     'Trage hier ein, wieviele .txt-Dateien im Ordner vorhanden sind:',
     'find chaos/ -name "*.txt" | wc',
-    -> () { read_console_i == 32771 }
+    -> () { read_console_i == CHAOS_TXT_FILE_COUNT }
 )
 
 # grep
@@ -822,6 +824,23 @@ CHAOS_FILE_COUNT = 66893
        end
     end
 )
+
+@exercises << Exercise.new(
+    'Kein unkalkuliertes Business!',
+    'Machen Sie sich mit der Funktionsweise von "bc" vertraut.',
+    %Q{
+      Jetzt wo Sie wissen, wieviel Schnitzelrezepte Sie noch speichern können, fragen Sie sich, wieviele Schnitzel Sie auf dieser Insel verkaufen können.
+      Kurzerhand entscheiden Sie sich mithilfe einer Bestechung an die Verkaufszahlen der Konkurrenz zu kommen.
+      Nachdem Sie einen Finanzamtmitarbeiter mit einem Schnitzel bestochen haben, lässt dieser fallen, dass der Umsatz Ihres Konkurrenten etwa 3108 hoch 2000 beträgt.
+      Da Sie dem Finanzamtmitarbeiter nicht trauen, beschließen Sie, diese Zahlen mit Ihrem Rechner auf Plausibilität zu prüfen.
+
+      Benutzen Sie das Kommando `bc`, um herauszufinden, wieviel 3108 hoch 2000 beträgt.
+    },
+    'Geben Sie die letzte Zeile des Ergebnisses an',
+    "",
+    -> () { read_console == '9443143978953998187590546511579035962672599269376' }
+)
+
 
 
 start = next_exercise_from_log

--- a/src/exercises/27_bc.rb
+++ b/src/exercises/27_bc.rb
@@ -1,0 +1,17 @@
+# bc
+@exercises << Exercise.new(
+    'Kein unkalkuliertes Business!',
+    'Machen Sie sich mit der Funktionsweise von "bc" vertraut.',
+    %Q{
+      Jetzt wo Sie wissen, wieviel Schnitzelrezepte Sie noch speichern können, fragen Sie sich, wieviele Schnitzel Sie auf dieser Insel verkaufen können.
+      Kurzerhand entscheiden Sie sich mithilfe einer Bestechung an die Verkaufszahlen der Konkurrenz zu kommen.
+      Nachdem Sie einen Finanzamtmitarbeiter mit einem Schnitzel bestochen haben, lässt dieser fallen, dass der Umsatz Ihres Konkurrenten etwa 3108 hoch 2000 beträgt.
+      Da Sie dem Finanzamtmitarbeiter nicht trauen, beschließen Sie, diese Zahlen mit Ihrem Rechner auf Plausibilität zu prüfen.
+
+      Benutzen Sie das Kommando `bc`, um herauszufinden, wieviel 3108 hoch 2000 beträgt.
+    },
+    'Geben Sie hier die letzte Zeile des Ergebnisses an:',
+    'echo "(3108^2000)" | bc',
+    -> () { read_console == '9443143978953998187590546511579035962672599269376' }
+)
+

--- a/src/exercises/27_bc.rb
+++ b/src/exercises/27_bc.rb
@@ -9,6 +9,8 @@
       Da Sie dem Finanzamtmitarbeiter nicht trauen, beschließen Sie, diese Zahlen mit Ihrem Rechner auf Plausibilität zu prüfen.
 
       Benutzen Sie das Kommando `bc`, um herauszufinden, wieviel 3108 hoch 2000 beträgt.
+
+      Tipp: Das Ergebnis wird von bc in mehrere Zeilen unterteilt. Diese sind mit einem "\\" getrennt.
     },
     'Geben Sie hier die letzte Zeile des Ergebnisses an:',
     'echo "3108^2000" | bc',

--- a/src/exercises/27_bc.rb
+++ b/src/exercises/27_bc.rb
@@ -11,7 +11,7 @@
       Benutzen Sie das Kommando `bc`, um herauszufinden, wieviel 3108 hoch 2000 beträgt.
     },
     'Geben Sie hier die letzte Zeile des Ergebnisses an:',
-    'echo "(3108^2000)" | bc',
+    'echo "3108^2000" | bc',
     -> () { read_console == '9443143978953998187590546511579035962672599269376' }
 )
 

--- a/src/schnitzel.rb
+++ b/src/schnitzel.rb
@@ -47,6 +47,7 @@ require_relative 'exercises/23_ps_kill.rb'
 require_relative 'exercises/24_cal.rb'
 require_relative 'exercises/25_df.rb'
 require_relative 'exercises/26_du.rb'
+require_relative 'exercises/27_bc.rb'
 
 start = next_exercise_from_log
 


### PR DESCRIPTION
Added bc exercise.

Knowing how to calculate with the command line is always good.
The user needs to answer with the last line of the result, this ensures that they don’t use other calculators.
The lines are cut by \ so it's clear how long the last line goes even when the user minimizes his terminal window.

Added in this pull request:
 * Exercise 27 (bc command)
 * included new exercise in schnitzel.rb
 * Updated schnitzel file